### PR TITLE
Add AgentProxyTool

### DIFF
--- a/src/strands/__init__.py
+++ b/src/strands/__init__.py
@@ -4,5 +4,16 @@ from . import agent, event_loop, models, telemetry, types
 from .agent.agent import Agent
 from .tools.decorator import tool
 from .tools.thread_pool_executor import ThreadPoolExecutorWrapper
+from .tools.agent_proxy_tool import AgentProxyTool
 
-__all__ = ["Agent", "ThreadPoolExecutorWrapper", "agent", "event_loop", "models", "tool", "types", "telemetry"]
+__all__ = [
+    "Agent",
+    "ThreadPoolExecutorWrapper",
+    "AgentProxyTool",
+    "agent",
+    "event_loop",
+    "models",
+    "tool",
+    "types",
+    "telemetry",
+]

--- a/src/strands/tools/__init__.py
+++ b/src/strands/tools/__init__.py
@@ -5,12 +5,20 @@ This module provides the core functionality for creating, managing, and executin
 
 from .decorator import tool
 from .thread_pool_executor import ThreadPoolExecutorWrapper
-from .tools import FunctionTool, InvalidToolUseNameException, PythonAgentTool, normalize_schema, normalize_tool_spec
+from .tools import (
+    FunctionTool,
+    InvalidToolUseNameException,
+    PythonAgentTool,
+    normalize_schema,
+    normalize_tool_spec,
+)
+from .agent_proxy_tool import AgentProxyTool
 
 __all__ = [
     "tool",
     "FunctionTool",
     "PythonAgentTool",
+    "AgentProxyTool",
     "InvalidToolUseNameException",
     "normalize_schema",
     "normalize_tool_spec",

--- a/src/strands/tools/agent_proxy_tool.py
+++ b/src/strands/tools/agent_proxy_tool.py
@@ -1,0 +1,47 @@
+"""Agent proxy tool for inter-agent communication."""
+
+from typing import Any, Optional
+
+from ..agent import AgentResult, Agent
+from ..types.tools import AgentTool, ToolResult, ToolSpec, ToolUse
+
+
+class AgentProxyTool(AgentTool):
+    """Wrap another :class:`~strands.agent.Agent` as a tool."""
+
+    def __init__(self, name: str, agent: Agent, description: Optional[str] = None) -> None:
+        super().__init__()
+        self._name = name
+        self.agent = agent
+        self._description = description or f"Send a message to agent '{name}'"
+
+    @property
+    def tool_name(self) -> str:
+        return self._name
+
+    @property
+    def tool_spec(self) -> ToolSpec:
+        return {
+            "name": self._name,
+            "description": self._description,
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                }
+            },
+        }
+
+    @property
+    def tool_type(self) -> str:
+        return "python"
+
+    def invoke(self, tool: ToolUse, *args: Any, **kwargs: dict[str, Any]) -> ToolResult:
+        message = tool.get("input", {}).get("message", "")
+        result: AgentResult = self.agent(message)
+        return {
+            "toolUseId": tool.get("toolUseId", "unknown"),
+            "status": "success",
+            "content": result.message.get("content", []),
+        }

--- a/tests/strands/tools/test_agent_proxy_tool.py
+++ b/tests/strands/tools/test_agent_proxy_tool.py
@@ -1,0 +1,48 @@
+import pytest
+from unittest.mock import MagicMock
+
+from strands.agent.agent import Agent
+from strands.agent.agent_result import AgentResult
+from strands.tools.agent_proxy_tool import AgentProxyTool
+
+
+@pytest.fixture
+def mock_agent():
+    agent = MagicMock(spec=Agent)
+    agent_result = AgentResult(
+        "end_turn",
+        {"role": "assistant", "content": [{"text": "pong"}]},
+        {},
+        {},
+    )
+    agent.return_value = agent_result
+    agent.__call__.return_value = agent_result
+    return agent
+
+
+@pytest.fixture
+def agent_tool(mock_agent):
+    return AgentProxyTool(name="helper", agent=mock_agent)
+
+
+def test_tool_name(agent_tool):
+    assert agent_tool.tool_name == "helper"
+
+
+def test_tool_type(agent_tool):
+    assert agent_tool.tool_type == "python"
+
+
+def test_tool_spec(agent_tool):
+    spec = agent_tool.tool_spec
+    assert spec["name"] == "helper"
+    assert "message" in spec["inputSchema"]["json"]["properties"]
+
+
+def test_invoke(agent_tool, mock_agent):
+    tool_use = {"toolUseId": "t1", "name": "helper", "input": {"message": "ping"}}
+    result = agent_tool.invoke(tool_use)
+    mock_agent.assert_called_once_with("ping")
+    assert result["toolUseId"] == "t1"
+    assert result["status"] == "success"
+    assert result["content"] == [{"text": "pong"}]


### PR DESCRIPTION
## Summary
- implement `AgentProxyTool` for routing a call from one agent to another
- expose `AgentProxyTool` in package initializers
- test the new inter-agent tool

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*